### PR TITLE
Fix on going dashboard work order connection

### DIFF
--- a/app/Exports/WorkOrdersExport.php
+++ b/app/Exports/WorkOrdersExport.php
@@ -17,12 +17,14 @@ class WorkOrdersExport implements FromView, ShouldAutoSize, WithEvents
     protected ?int $month;
     protected ?int $year;
     protected ?array $ids;
+    protected ?string $status;
 
-    public function __construct(?int $month = null, ?int $year = null, ?array $ids = null)
+    public function __construct(?int $month = null, ?int $year = null, ?array $ids = null, ?string $status = null)
     {
         $this->month = $month;
         $this->year = $year;
         $this->ids = $ids;
+        $this->status = $status;
     }
 
     protected function query(): Collection
@@ -31,6 +33,11 @@ class WorkOrdersExport implements FromView, ShouldAutoSize, WithEvents
 
         if (!empty($this->ids)) {
             return $query->whereIn('id', $this->ids)->latest()->get();
+        }
+
+        // Filter berdasarkan status jika ada
+        if ($this->status) {
+            $query->where('status', $this->status);
         }
 
         if ($this->month && $this->year) {

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -56,7 +56,10 @@
 
                         {{-- Panel Filter --}}
                         <div class="p-3 mb-4 filter-panel">
-                            <form action="{{ route('dashboard') }}" method="GET">
+                            <form action="{{ route('dashboard', $status ? ['status' => $status] : []) }}" method="GET">
+                                @if($status)
+                                    <input type="hidden" name="route_status" value="{{ $status }}">
+                                @endif
                                 <div class="row g-3 align-items-end">
                                     <div class="col-md-3">
                                         <label for="search" class="form-label fw-bold">Pencarian</label>
@@ -68,10 +71,10 @@
                                         <select name="filter_status" id="filter_status" class="form-select">
                                             <option value="">Semua Status</option>
                                             <option value="On Progress"
-                                                {{ request('filter_status') == 'On Progress' ? 'selected' : '' }}>On
+                                                {{ (request('filter_status') == 'On Progress' || $status == 'On Progress') ? 'selected' : '' }}>On
                                                 Progress</option>
                                             <option value="Completed"
-                                                {{ request('filter_status') == 'Completed' ? 'selected' : '' }}>
+                                                {{ (request('filter_status') == 'Completed' || $status == 'Completed') ? 'selected' : '' }}>
                                                 Completed
                                             </option>
                                         </select>
@@ -106,7 +109,7 @@
                                 </div>
                                 <div class="row mt-3">
                                     <div class="col-12 text-end">
-                                        <a href="{{ route('dashboard') }}" class="btn btn-outline-secondary">Reset</a>
+                                        <a href="{{ route('dashboard', $status ? ['status' => $status] : []) }}" class="btn btn-outline-secondary">Reset</a>
                                         <button class="btn btn-primary" type="submit">Filter</button>
                                     </div>
                                 </div>
@@ -156,6 +159,12 @@
                                                         'sort_by' => $column,
                                                         'sort_direction' => $newDirection,
                                                     ]);
+                                                    
+                                                    // Jika ada status dari route, tambahkan ke URL
+                                                    if (isset($status) && $status) {
+                                                        $url = $url . '&status=' . $status;
+                                                    }
+                                                    
                                                     // Menambahkan jangkar ke URL
                                                     return '<th><a href="' .
                                                         $url .
@@ -550,6 +559,11 @@
                         if (checkedIds.length > 0) {
                             checkedIds.forEach(id => params.append('ids[]', id));
                         }
+
+                        // Tambahkan status filter jika ada
+                        @if(isset($status) && $status)
+                        params.set('status', '{{ $status }}');
+                        @endif
 
                         window.location.href = baseUrl + (params.toString() ? ('?' + params.toString()) : '');
                     });


### PR DESCRIPTION
Fixes the dashboard's "Ongoing" feature to correctly filter and preserve work order status across all dashboard operations.

The previous implementation failed to correctly interpret the 'On Progress' status when passed as a route parameter from the sidebar, leading to unfiltered results. This PR updates the controller, view, and export logic to consistently handle and persist the status filter, ensuring all dashboard functionalities (filtering, sorting, exporting) respect the currently selected work order status.

---
<a href="https://cursor.com/background-agent?bcId=bc-bdf93a47-c911-43ec-973b-b1186643d741">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bdf93a47-c911-43ec-973b-b1186643d741">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

