### PR TITLE
Fix on going dashboard work order connection

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -59,6 +59,11 @@ class DashboardController extends Controller
         // Logika untuk admin
         $query = WorkOrder::with('woDiterimaTracking');
 
+        // Filter berdasarkan status dari route parameter (jika ada)
+        if (in_array($status, ['On Progress', 'Completed'])) {
+            $query->where('status', $status);
+        }
+
         // Filter berdasarkan pencarian
         if ($request->filled('search')) {
             $search = $request->search;
@@ -68,7 +73,7 @@ class DashboardController extends Controller
             });
         }
 
-        // Filter berdasarkan status
+        // Filter berdasarkan status dari form (jika ada)
         if ($request->filled('filter_status')) {
             $query->where('status', $request->filter_status);
         }
@@ -109,7 +114,7 @@ class DashboardController extends Controller
         }
 
         $workOrders = $query->paginate(10)->withQueryString();
-        return view('dashboard', compact('workOrders'));
+        return view('dashboard', compact('workOrders', 'status'));
     }
 
     /**

--- a/resources/views/layouts/sidebar.blade.php
+++ b/resources/views/layouts/sidebar.blade.php
@@ -31,7 +31,7 @@
             </a>
         </li>
         <li class="nav-item">
-            <a class="nav-link {{ request()->routeIs('dashboard') ? 'active' : '' }}" href="{{ route('dashboard') }}">
+            <a class="nav-link {{ request()->routeIs('dashboard') ? 'active' : '' }}" data-bs-toggle="collapse" href="#workorder-submenu" role="button" aria-expanded="false" aria-controls="workorder-submenu">
                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
                     stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                     <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
@@ -42,6 +42,19 @@
                 </svg>
                 Work Orders
             </a>
+            <div class="collapse" id="workorder-submenu">
+                <ul class="nav flex-column ms-3">
+                    <li class="nav-item">
+                        <a class="nav-link" href="{{ route('dashboard') }}">Semua Work Order</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="{{ route('dashboard', ['status' => 'On Progress']) }}">Dalam Pengerjaan</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="{{ route('dashboard', ['status' => 'Completed']) }}">Selesai</a>
+                    </li>
+                </ul>
+            </div>
         </li>
         <li class="nav-item">
             <a class="nav-link {{ request()->routeIs('users.*') ? 'active' : '' }}" href="{{ route('users.index') }}">


### PR DESCRIPTION
Fixes dashboard's "On Progress" work order filtering by correctly applying route status parameters and enhances UI/UX for status navigation.

The `DashboardController` for admin users previously ignored the `status` route parameter (e.g., `/dashboard/On Progress`), only applying filters from form submissions. This PR ensures the route parameter is respected, allowing direct navigation to filtered "On Progress" work orders, and improves the user experience with better navigation and visual feedback.

---
<a href="https://cursor.com/background-agent?bcId=bc-4fb075f0-6d00-4876-9afe-1afada1fff23">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4fb075f0-6d00-4876-9afe-1afada1fff23">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

